### PR TITLE
Modified tags and decode_raw() for classes in HeaderFile

### DIFF
--- a/init.py
+++ b/init.py
@@ -1,4 +1,5 @@
 from x690 import decode
+from x690.types import Type
 from x690.util import decode_length, visible_octets
 
 import etypes as etypes
@@ -12,6 +13,9 @@ def readFile():
     data = open(file, "rb").read()
     value, nxt = decode(data)
     print(value.pretty())
+
+    # for x in Type.all():
+    #    print(x)
 
     while nxt < len(data):
         value, nxt = decode(data, nxt)
@@ -28,13 +32,13 @@ def readTag():
         decoded, nxt = decode(data)
         print(MeasFileFooter.decode_raw(data))
         print(MeasFileFooter.get_time(data))
-        print(MeasFileFooter.get_timezone(data))
+        print(MeasFilqeFooter.get_timezone(data))
         print(FileFooter.get_time(data))
         print(FileFooter.get_timezone(data))
     """
 
-    print(etypes.FileFooter.decode_raw(data))
-    print(etypes.FileFooter.use_gentime(data))
+    # print(etypes.FileFooter.decode_raw(data))
+    # print(etypes.FileFooter.use_gentime(data))
 
 
 def readHeader():
@@ -44,5 +48,6 @@ def readHeader():
 
 
 # readTag()
+# readHeader()
+
 readFile()
-readHeader()

--- a/parsesyn.py
+++ b/parsesyn.py
@@ -3,7 +3,7 @@
     decoded header definition
 """
 
-import etypes as etypes
+import etypes as etypesgit
 
 
 class DefinitionType:


### PR DESCRIPTION
- Resetted all tag definitions in _etypes.py_:

```
DataCollection
{
  T[160, C, C, 0]   FileHeader
  T[161, C, C, 1]   Data
  T[130, C, P, 2]   FileFooter
}

FileHeader
{
  T[128, C, P, 0]   FileFormatVersion
  T[129, C, P, 1]   SenderName
  T[130, -, -, -]   SenderType (undefined, length = 0)
  T[131, C, P, 3]   VendorName
  T[132, C, P, 4]   CollectionStartTime
}
```
- Rewrote decode_raw() for CollStartTime() and FileFooter()
- Added dataclass for FileHeader()